### PR TITLE
Support CredHub's CF Instance Identity roles

### DIFF
--- a/bin/fetch-credhub-credentials.rb
+++ b/bin/fetch-credhub-credentials.rb
@@ -6,6 +6,11 @@ $base_path = ARGV[0]
 env_dir = ARGV[1]
 file_dir = ARGV[2]
 
+if ENV["CREDHUB_USE_CF_INSTANCE_IDENTITY"] == "true"
+  ENV["CREDHUB_CLIENT_CERT_PATH"] = ENV["CF_INSTANCE_CERT"]
+  ENV["CREDHUB_CLIENT_KEY_PATH"] = ENV["CF_INSTANCE_KEY"]
+end
+
 login_stdout, login_stderr, login_status = Open3.capture3('credhub login')
 if login_status != 0
   STDERR.puts 'Could not login in to CredHub, check the contents of $CREDHUB_SERVER, $CREDHUB_CA_CERT, $CREDHUB_CLIENT and $CREDHUB_SECRET environment variables'


### PR DESCRIPTION
Hi Andy 👋  This is to address #1.

## What

Cloud Foundry provides all apps with certificates containing their identity, a system called Instance Identity [1]. You can use these certificates to connect to CredHub using Mutual TLS, and when you do you get the role `mtls-app:APP_GUID` [2].

This PR adds a new `CREDHUB_USE_CF_INSTANCE_IDENTITY` environment variable. When set to true it will configure CredHub to use the Instance Identity certificates, and all CredHub commands will be run using that `mtls-app:APP_GUID` role.

I think this has a lot of value in an automated, brokered CredHub like the one I'm working on in my `credhub-service-broker` [3].

This feature will only work if the buildpack is built to include a version of the CredHub CLI that supports using client certificates. I have a PR open for that [4].

[1] https://docs.cloudfoundry.org/devguide/deploy-apps/instance-identity.html
[2] https://github.com/cloudfoundry-incubator/credhub/blob/master/docs/authentication-identities.md
[3] https://github.com/46bit/credhub-service-broker
[4] https://github.com/cloudfoundry-incubator/credhub-cli/pull/103

## How to review

For now I'm interested in whether you'd merge this. :)